### PR TITLE
AUTHYM-2928 Phone number cached when retrying verification

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -34,12 +34,11 @@ dependencies {
         exclude module: 'recyclerview-v7'
 
     })
-    compile 'com.twilio:verification:1.0.0'
+    compile 'com.twilio:verification:1.0.1'
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support:design:25.3.1'
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
     compile 'com.google.android.gms:play-services-auth:10.2.5'
     compile 'com.squareup.okhttp3:logging-interceptor:3.6.0'
-    compile 'com.auth0.android:jwtdecode:1.1.1'
     testCompile 'junit:junit:4.12'
 }

--- a/sample/src/main/java/com/twilio/verification/sample/VerificationPresenter.java
+++ b/sample/src/main/java/com/twilio/verification/sample/VerificationPresenter.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
-import com.auth0.android.jwt.JWT;
 import com.twilio.verification.TwilioVerification;
 import com.twilio.verification.external.VerificationStatus;
 import com.twilio.verification.external.Via;
@@ -33,7 +32,6 @@ public class VerificationPresenter {
     private TwilioVerification twilioVerification;
     private TokenServerApi tokenServerApi;
     private Via via;
-    private JWT jwtToken;
 
     public VerificationPresenter(Context context) {
         twilioVerification = new TwilioVerification(context);
@@ -95,13 +93,7 @@ public class VerificationPresenter {
         this.via = via;
         view.updateView(VerificationUIModel.inProgress(via));
 
-        if (jwtToken == null || jwtToken.isExpired(0)) {
-            getTokenAndStartVerification(phoneNumber, via);
-        } else {
-            twilioVerification.startVerification(
-                    jwtToken.toString(),
-                    via);
-        }
+        getTokenAndStartVerification(phoneNumber, via);
     }
 
     private void getTokenAndStartVerification(final String phoneNumber, final Via via) {
@@ -109,9 +101,8 @@ public class VerificationPresenter {
             @Override
             public void onResponse(Call<TokenServerResponse> call, Response<TokenServerResponse> tokenServerResponse) {
                 if (tokenServerResponse != null && tokenServerResponse.body() != null) {
-                    jwtToken = new JWT(tokenServerResponse.body().getJwtToken());
                     twilioVerification.startVerification(
-                            jwtToken.toString(),
+                            tokenServerResponse.body().getJwtToken(),
                             via);
                     return;
                 }

--- a/sample/src/main/res/layout/activity_verification.xml
+++ b/sample/src/main/res/layout/activity_verification.xml
@@ -7,14 +7,17 @@
     <TextView
         android:id="@+id/verify_title"
         style="@style/Title"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginLeft="24dp"
+        android:layout_marginRight="24dp"
         android:layout_marginStart="24dp"
         android:layout_marginTop="40dp"
         android:text="@string/verify_title_label"
         app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_default="wrap" />
 
     <TextView
         android:id="@+id/verify_message"


### PR DESCRIPTION
## JIRA
AUTHYM-2928

## Changes
* Removed caching of JWT which caused the phone number to be mistakenly cached
* Fixed layout error on small width displays for activity title

## Checklist
- [x] Did you run the tests? (TODO: Automate this)
- [x] Did you add the labels? (hotfix, vulnerability, new-feature, task, ui, needs-security-review)
- [ ] Is new code covered?
- [ ] Is code instrumented?
- [ ] New fields validated?
- [ ] User inputs validated?
- [x] All errors handled?
- [ ] Enough logging?
